### PR TITLE
mainからrender_for_tomorrow関数を削除

### DIFF
--- a/class/tv_info_tweet.rb
+++ b/class/tv_info_tweet.rb
@@ -29,8 +29,11 @@ class TVInfoTweets
     puts @tweets
   end
 
-  def render_for_30_min_later(data, now, after_30_min)
-    if data[:date][:start] > now && data[:date][:start] < after_30_min
+  def render_for_30_min_later(data)
+    now = Time.now
+    after_30_min = now + 30 * 60
+
+    if data[:date][:start] > now && data[:date][:start] <= after_30_min
       tweet_text = MakeText.new(data[:name], data[:title], data[:channel], data[:date][:start])
       @tweets << tweet_text.for_30_min_later
     end

--- a/main.rb
+++ b/main.rb
@@ -17,12 +17,9 @@ module Clockwork
       ENV.fetch('TWITTER_ACCESS_TOKEN_SECRET')
     )
     all_data = GetTVInfo.new(ENV.fetch('PERSON_NAME')).get_all_rss()
-  
+
     all_data.each do |data|
-      now = Time.now
-      after_30_min = now + 30 * 60
-      tweets.render_for_30_min_later(data, now, after_30_min)
-      tweets.render_for_tomorrow(data, now)
+      tweets.render_for_30_min_later(data)
     end
     tweets.tweet_all
   end


### PR DESCRIPTION
TVInfoTweetsクラスからrender_for_tomorrowメソッドが削除されましたが、main.rbに残ってしまうことを気づきました。
もし良ければマージお願いします。